### PR TITLE
Uses python:3.11-bullseye as base image

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
-#FROM python:3.11-bullseye
-FROM ubuntu:22.04
+FROM python:3.11-bullseye
+#FROM ubuntu:22.04
 
 # Set environment variables
 ENV DEBIAN_FRONTEND=noninteractive

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,13 +1,13 @@
-FROM python:3.11-bullseye
-#FROM ubuntu:22.04
+FROM python:3.11-bookworm
 
 # Set environment variables
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Update the package list and install necessary packages
 RUN apt-get update && \
-    apt-get install -y python3-dev python3-louis python3-pip libcairo2-dev pkg-config npm nodejs librsvg2-bin && \
+    apt-get install -y python3-louis python3-pip npm nodejs libcairo2-dev pkg-config librsvg2-bin && \
     apt-get clean
 
-RUN python3 -m pip install --upgrade pip
+# Debian bookworm has a new enough pip we can skip this
+# RUN python3 -m pip install --upgrade pip
 RUN pip install prefig

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
+cat .my_bashrc >> ~/.bashrc
+. ~/.bashrc
 prefig init
 prefig new
 prefig examples
-cat .my_bashrc >> ~/.bashrc
-. ~/.bashrc

--- a/.my_bashrc
+++ b/.my_bashrc
@@ -22,3 +22,4 @@ __bash_prompt() {
 }
 __bash_prompt
 export PROMPT_DIRTRIM=4
+export PYTHONPATH="/usr/lib/python3/dist-packages"


### PR DESCRIPTION
Played around with this for a bit; got it working on bullseye with minimal changes. I added a PYTHONPATH to ~/.bashrc to fix the import error when python3-louis is installed but it can't find it.